### PR TITLE
Update v4.12

### DIFF
--- a/Facebook.AudienceNetwork.iOS/build.cake
+++ b/Facebook.AudienceNetwork.iOS/build.cake
@@ -2,8 +2,8 @@
 #load "../common.cake"
 
 var SDK_DATE = "20160412";
-var SDK_VERSION = "4.11.0.0";
-var SDK_URL = string.Format ("https://origincache.facebook.com/developers/resources/?id=FacebookSDKs-iOS-{0}.zip", SDK_DATE);
+var SDK_VERSION = "4.12.0";
+var SDK_URL = string.Format ("https://origincache.facebook.com/developers/resources/?id=FacebookSDKs-iOS-{0}.zip", SDK_VERSION);
 var SDK_FILE = "FacebookSDKs-iOS.zip";
 var SDK_PATH = "./externals/FacebookSDKs";
 

--- a/Facebook.AudienceNetwork.iOS/component/component.yaml
+++ b/Facebook.AudienceNetwork.iOS/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.11.0.0
+version: 4.12.0.0
 name: Facebook Audience Network iOS SDK
 id: fbaudiencenetworkios
 publisher: Xamarin Inc

--- a/Facebook.AudienceNetwork.iOS/samples/FBAudienceNetworkSample/FBAudienceNetworkSample/FBAudienceNetworkSample.csproj
+++ b/Facebook.AudienceNetwork.iOS/samples/FBAudienceNetworkSample/FBAudienceNetworkSample/FBAudienceNetworkSample.csproj
@@ -76,6 +76,8 @@
     </MtouchI18n>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchExtraArgs></MtouchExtraArgs>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>full</DebugType>

--- a/Facebook.AudienceNetwork.iOS/samples/FBAudienceNetworkSample/FBAudienceNetworkSample/Info.plist
+++ b/Facebook.AudienceNetwork.iOS/samples/FBAudienceNetworkSample/FBAudienceNetworkSample/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>FBAudienceNetworkSample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.your-company.FBAudienceNetworkSample</string>
+	<string>com.xamarin.FBAudienceNetworkSample</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/ApiDefinition.cs
+++ b/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/ApiDefinition.cs
@@ -45,6 +45,11 @@ namespace Facebook.AudienceNetwork
 		[Export ("corner", ArgumentSemantic.Assign)]
 		UIRectCorner Corner { get; set; }
 
+		// @property (nonatomic, weak, readwrite, nullable) UIViewController *viewController;
+		[NullAllowed]
+		[Export ("viewController", ArgumentSemantic.Weak)]
+		UIViewController ViewController { get; set; }
+
 		// -(instancetype)initWithNativeAd:(FBNativeAd *)nativeAd;
 		[Export ("initWithNativeAd:")]
 		IntPtr Constructor (NativeAd nativeAd);
@@ -55,16 +60,16 @@ namespace Facebook.AudienceNetwork
 
 		// -(instancetype)initWithViewController:(UIViewController *)viewController adChoicesIcon:(FBAdImage *)adChoicesIcon adChoicesLinkURL:(NSURL *)adChoicesLinkURL attributes:(FBNativeAdViewAttributes *)attributes __attribute__((objc_designated_initializer));
 		[Export ("initWithViewController:adChoicesIcon:adChoicesLinkURL:attributes:")]
-		IntPtr Constructor (UIViewController viewController, AdImage adChoicesIcon, NSUrl adChoicesLinkURL, [NullAllowed] NativeAdViewAttributes attributes);
+		IntPtr Constructor ([NullAllowed] UIViewController viewController, AdImage adChoicesIcon, NSUrl adChoicesLinkURL, [NullAllowed] NativeAdViewAttributes attributes);
 
 		// -(instancetype)initWithViewController:(UIViewController *)viewController adChoicesIcon:(FBAdImage *)adChoicesIcon adChoicesLinkURL:(NSURL *)adChoicesLinkURL attributes:(FBNativeAdViewAttributes *)attributes expandable:(BOOL)expandable __attribute__((objc_designated_initializer));
 		[Export ("initWithViewController:adChoicesIcon:adChoicesLinkURL:attributes:expandable:")]
-		IntPtr Constructor (UIViewController viewController, AdImage adChoicesIcon, NSUrl adChoicesLinkURL, [NullAllowed] NativeAdViewAttributes attributes, bool expandable);
+		IntPtr Constructor ([NullAllowed] UIViewController viewController, AdImage adChoicesIcon, NSUrl adChoicesLinkURL, [NullAllowed] NativeAdViewAttributes attributes, bool expandable);
 
 		// -(instancetype)initWithViewController:(UIViewController *)viewController adChoicesIcon:(FBAdImage *)adChoicesIcon adChoicesLinkURL:(NSURL *)adChoicesLinkURL adChoicesText:(nullable NSString*)adChoicesText attributes:(FBNativeAdViewAttributes *)attributes expandable:(BOOL)expandable __attribute__((objc_designated_initializer));
 		[DesignatedInitializer]
 		[Export ("initWithViewController:adChoicesIcon:adChoicesLinkURL:adChoicesText:attributes:expandable:")]
-		IntPtr Constructor (UIViewController viewController, AdImage adChoicesIcon, NSUrl adChoicesLinkURL, [NullAllowed] string adChoicesText, [NullAllowed] NativeAdViewAttributes attributes, bool expandable);
+		IntPtr Constructor ([NullAllowed] UIViewController viewController, AdImage adChoicesIcon, NSUrl adChoicesLinkURL, [NullAllowed] string adChoicesText, [NullAllowed] NativeAdViewAttributes attributes, bool expandable);
 
 		// -(void)updateFrameFromSuperview;
 		[Export ("updateFrameFromSuperview")]
@@ -146,7 +151,7 @@ namespace Facebook.AudienceNetwork
 
 		[DesignatedInitializer]
 		[Export ("initWithPlacementID:adSize:rootViewController:")]
-		IntPtr Constructor (string placementID, AdSize adSize, UIViewController viewController);
+		IntPtr Constructor (string placementID, AdSize adSize, [NullAllowed] UIViewController viewController);
 
 		[Export ("loadAd")]
 		void LoadAd ();
@@ -214,7 +219,7 @@ namespace Facebook.AudienceNetwork
 		void LoadAd ();
 
 		[Export ("showAdFromRootViewController:")]
-		bool ShowAdFromRootViewController (UIViewController rootViewController);
+		bool ShowAdFromRootViewController ([NullAllowed] UIViewController rootViewController);
 	}
 
 	interface IInterstitialAdDelegate
@@ -330,10 +335,10 @@ namespace Facebook.AudienceNetwork
 		IntPtr Constructor (string placementId);
 
 		[Export ("registerViewForInteraction:withViewController:")]
-		void RegisterView (UIView view, UIViewController viewController);
+		void RegisterView (UIView view, [NullAllowed] UIViewController viewController);
 
 		[Export ("registerViewForInteraction:withViewController:withClickableViews:")]
-		void RegisterView (UIView view, UIViewController viewController, UIView [] clickableViews);
+		void RegisterView (UIView view, [NullAllowed] UIViewController viewController, UIView [] clickableViews);
 
 		[Export ("unregisterView")]
 		void UnregisterView ();

--- a/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/ApiDefinition.cs
+++ b/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/ApiDefinition.cs
@@ -125,19 +125,23 @@ namespace Facebook.AudienceNetwork
 	{
 		[Internal]
 		[Field ("kFBAdSize320x50", "__Internal")]
-		IntPtr _kFBAdSize320x50Global { get; }
+		IntPtr _kFBAdSize320x50 { get; }
 
 		[Internal]
 		[Field ("kFBAdSizeHeight50Banner", "__Internal")]
-		IntPtr _kFBAdSizeHeight50BannerGlobal { get; }
+		IntPtr _kFBAdSizeHeight50Banner { get; }
 
 		[Internal]
 		[Field ("kFBAdSizeHeight90Banner", "__Internal")]
-		IntPtr _kFBAdSizeHeight90BannerGlobal { get; }
+		IntPtr _kFBAdSizeHeight90Banner { get; }
+
+		[Internal]
+		[Field ("kFBAdSizeInterstitial", "__Internal")]
+		IntPtr _kFBAdSizeInterstitial { get; }
 
 		[Internal]
 		[Field ("kFBAdSizeInterstital", "__Internal")]
-		IntPtr _kFBAdSizeInterstitalGlobal { get; }
+		IntPtr _kFBAdSizeInterstital { get; }
 
 		[Internal]
 		[Field ("kFBAdSizeHeight250Rectangle", "__Internal")]

--- a/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/Facebook.AudienceNetwork.linkwith.cs
+++ b/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/Facebook.AudienceNetwork.linkwith.cs
@@ -4,6 +4,6 @@ using System.Reflection;
 using ObjCRuntime;
 using Foundation;
 
-[assembly: AssemblyVersion ("4.10.0.0")]
+[assembly: AssemblyVersion ("4.12.0.0")]
 [assembly: LinkerSafe]
-[assembly: LinkWith ("Facebook.AudienceNetwork.a", LinkTarget.Simulator | LinkTarget.Simulator64 | LinkTarget.ArmV7 | LinkTarget.Arm64, Frameworks = "AdSupport AVFoundation CoreImage CoreMedia CoreMotion OpenGLES QuartzCore Security StoreKit", SmartLink = true, ForceLoad = true)]
+[assembly: LinkWith ("Facebook.AudienceNetwork.a", LinkTarget.Simulator | LinkTarget.Simulator64 | LinkTarget.ArmV7 | LinkTarget.Arm64, Frameworks = "AVFoundation CoreGraphics CoreImage CoreMedia OpenGLES QuartzCore Security StoreKit", WeakFrameworks = "AdSupport CoreMotion SafariServices WebKit", LinkerFlags = "-lc++ -lxml2", SmartLink = true, ForceLoad = true)]

--- a/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/StructsAndEnums.cs
+++ b/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/StructsAndEnums.cs
@@ -27,13 +27,14 @@ namespace Facebook.AudienceNetwork
 		Verbose
 	}
 
+	[Flags]
 	[Native]
 	public enum NativeAdsCachePolicy : long
 	{
-		None = 0,
-		Icon = 0x1,
-		CoverImage = 0x2,
-		Video = 0x3,
+		None = 1 << 0,
+		Icon = 1 << 1,
+		CoverImage = 1 << 2,
+		Video = 1 << 3,
 		All = Icon | CoverImage | Video
 	}
 

--- a/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/extensions.cs
+++ b/Facebook.AudienceNetwork.iOS/source/Facebook.AudienceNetwork/extensions.cs
@@ -15,6 +15,7 @@ using ObjCRuntime;
 
 namespace Facebook.AudienceNetwork
 {
+	[Preserve (AllMembers = true)]
 	public static partial class AdSizes
 	{
 		static AdSize? size320x50;
@@ -66,16 +67,32 @@ namespace Facebook.AudienceNetwork
 			}
 		}
 
+		static AdSize? interstitial;
+
+		public static AdSize Interstitial {
+			get {
+				if (interstitial != null)
+					return interstitial.Value;
+
+				IntPtr RTLD_MAIN_ONLY = Dlfcn.dlopen (null, 0);
+				IntPtr ptr = Dlfcn.dlsym (RTLD_MAIN_ONLY, "kFBAdSizeInterstitial");
+				interstitial = (AdSize)Marshal.PtrToStructure (ptr, typeof (AdSize));
+				Dlfcn.dlclose (RTLD_MAIN_ONLY);
+
+				return interstitial.Value;
+			}
+		}
+
 		static AdSize? interstital;
 
-		[Obsolete]
+		[Obsolete ("Use Interstitial instead.")]
 		public static AdSize Interstital {
 			get {
 				if (interstital != null)
 					return interstital.Value;
 
 				IntPtr RTLD_MAIN_ONLY = Dlfcn.dlopen (null, 0);
-				IntPtr ptr = Dlfcn.dlsym (RTLD_MAIN_ONLY, "kFBAdSizeInterstital");
+				IntPtr ptr = Dlfcn.dlsym (RTLD_MAIN_ONLY, "kFBAdSizeInterstitial");
 				interstital = (AdSize)Marshal.PtrToStructure (ptr, typeof (AdSize));
 				Dlfcn.dlclose (RTLD_MAIN_ONLY);
 

--- a/Facebook.iOS/build.cake
+++ b/Facebook.iOS/build.cake
@@ -2,8 +2,8 @@
 #load "../common.cake"
 
 var SDK_DATE = "20160412";
-var SDK_VERSION = "4.11.0.0";
-var SDK_URL = string.Format ("https://origincache.facebook.com/developers/resources/?id=FacebookSDKs-iOS-{0}.zip", SDK_DATE);
+var SDK_VERSION = "4.12.0";
+var SDK_URL = string.Format ("https://origincache.facebook.com/developers/resources/?id=FacebookSDKs-iOS-{0}.zip", SDK_VERSION);
 var SDK_FILE = "FacebookSDKs-iOS.zip";
 var SDK_PATH = "./externals/FacebookSDKs";
 

--- a/Facebook.iOS/component/component.yaml
+++ b/Facebook.iOS/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.11.0.1
+version: 4.12.0.0
 name: Facebook iOS SDK
 id: facebookios
 publisher: Xamarin Inc
@@ -11,7 +11,7 @@ icons:
   - icons/facebookios_512x512.png
 packages:
   ios-unified:
-    - Xamarin.Facebook.iOS, Version=4.11.0.1
+    - Xamarin.Facebook.iOS, Version=4.12.0.0
 libraries:
   ios-unified:
     - ../output/unified/Facebook.dll

--- a/Facebook.iOS/nuget/Xamarin.Facebook.iOS.nuspec
+++ b/Facebook.iOS/nuget/Xamarin.Facebook.iOS.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Facebook.iOS</id>
     <title>Facebook SDK for Xamarin iOS</title>
-    <version>4.11.0.1</version>
+    <version>4.12.0.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Facebook.iOS/samples/FacebookiOSSample/ListDetailViewController.cs
+++ b/Facebook.iOS/samples/FacebookiOSSample/ListDetailViewController.cs
@@ -39,7 +39,7 @@ namespace FacebookiOSSample
 				// Add the name and the picture profile to the view
 				for (nuint i = 0; i < membersData.Count; i++) {
 					// Get the info of one of the members
-					var memberData = membersData.GetItem <NSDictionary> (i);
+					var memberData = membersData.GetItem<NSDictionary> (i);
 					var pictureView = new ProfilePictureView (new CGRect (48, 0, 220, 220)) {
 						ProfileId = memberData ["id"].ToString (),
 						TranslatesAutoresizingMaskIntoConstraints = false
@@ -50,6 +50,11 @@ namespace FacebookiOSSample
 							Flags = UIViewElement.CellFlags.DisableSelection | UIViewElement.CellFlags.Transparent
 						}
 					});
+
+					pictureView.WidthAnchor.ConstraintEqualTo (220).Active = true;
+					pictureView.HeightAnchor.ConstraintEqualTo (220).Active = true;
+					pictureView.CenterXAnchor.ConstraintEqualTo (TableView.CenterXAnchor).Active = true;
+					//pictureView.CenterYAnchor.ConstraintEqualTo (0).Active = true;
 				}
 
 				Root = new RootElement (listName) {

--- a/Facebook.iOS/samples/FacebookiOSSample/ListDetailViewController.cs
+++ b/Facebook.iOS/samples/FacebookiOSSample/ListDetailViewController.cs
@@ -50,11 +50,6 @@ namespace FacebookiOSSample
 							Flags = UIViewElement.CellFlags.DisableSelection | UIViewElement.CellFlags.Transparent
 						}
 					});
-
-					pictureView.WidthAnchor.ConstraintEqualTo (220).Active = true;
-					pictureView.HeightAnchor.ConstraintEqualTo (220).Active = true;
-					pictureView.CenterXAnchor.ConstraintEqualTo (TableView.CenterXAnchor).Active = true;
-					//pictureView.CenterYAnchor.ConstraintEqualTo (0).Active = true;
 				}
 
 				Root = new RootElement (listName) {

--- a/Facebook.iOS/source/Facebook/ApiDefinition.cs
+++ b/Facebook.iOS/source/Facebook/ApiDefinition.cs
@@ -2022,6 +2022,11 @@ namespace Facebook.ShareKit
 		[Export ("graphNode", ArgumentSemantic.Copy)]
 		string GraphNode { get; set; }
 
+		// @property (nonatomic, strong) FBSDKAccessToken *accessToken;
+		[NullAllowed]
+		[Export ("accessToken", ArgumentSemantic.Strong)]
+		CoreKit.AccessToken AccessToken { get; set; }
+
 		// -(BOOL)canShare;
 		[Export ("canShare")]
 		bool CanShare ();

--- a/Facebook.iOS/source/Facebook/StructsAndEnums.cs
+++ b/Facebook.iOS/source/Facebook/StructsAndEnums.cs
@@ -25,7 +25,8 @@ namespace Facebook.CoreKit
 		DialogUnavailable,
 		AccessTokenRequired,
 		AppVersionUnsupported,
-		BrowswerUnavailable
+		BrowserUnavailable,
+		BrowswerUnavailable = BrowserUnavailable
 	}
 
 	[Native]


### PR DESCRIPTION
- Facebook iOS
  - Updated to version 4.12.0
- FB Audience Network iOS
  - Updated to version 4.12.0
  - Fixed AdSizes classes from being stripped
  - Fixed linkwith file
  - Fixed and added Interstitial Size to AdSizes class
