### PR TITLE
[facebook][android] Update to v4.25

### DIFF
--- a/Facebook.Android/build.cake
+++ b/Facebook.Android/build.cake
@@ -1,14 +1,14 @@
 
 #load "../common.cake"
 
-var FB_NUGET_VERSION = "4.24.0";
-var AN_NUGET_VERSION = "4.24.0";
+var FB_NUGET_VERSION = "4.25.0";
+var AN_NUGET_VERSION = "4.25.0";
 
-var FB_VERSION = "4.24.0";
+var FB_VERSION = "4.25.0";
 var FB_URL = string.Format ("http://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/{0}/facebook-android-sdk-{0}.aar", FB_VERSION);
 var FB_DOCS_URL = string.Format ("http://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/{0}/facebook-android-sdk-{0}-javadoc.jar", FB_VERSION);
 
-var AN_VERSION = "4.24.0";
+var AN_VERSION = "4.25.0";
 var AN_URL = string.Format ("http://search.maven.org/remotecontent?filepath=com/facebook/android/audience-network-sdk/{0}/audience-network-sdk-{0}.aar", AN_VERSION);
 
 var TARGET = Argument ("t", Argument ("target", "Default"));


### PR DESCRIPTION
This PR updates the Android binding to v4.25.

_Note: v4.26 for just the FB SDK is available (not the ads), but it has a dependency on `com.google.zxing:core`, which is not yet bound._

https://repo1.maven.org/maven2/com/facebook/android/facebook-android-sdk/4.26.0/facebook-android-sdk-4.26.0.pom