### PR TITLE
Fix ARMv7 (32bit) crashes on iOS & fix POD dependency resolution

### DIFF
--- a/Facebook.iOS/build.cake
+++ b/Facebook.iOS/build.cake
@@ -244,7 +244,7 @@ void CreateAndInstallPodfile (Artifact artifact)
 
 void BuildSdkOnPodfile (Artifact artifact)
 {
-	var platforms = new [] { Platform.iOSArm64, Platform.iOSArmV7, Platform.iOSSimulator64, Platform.iOSSimulator };
+	var platforms = new [] { baseBuildArch, Platform.iOSArm64, Platform.iOSSimulator64, Platform.iOSSimulator };
 
 	var podsProject = "./Pods/Pods.xcodeproj";
 	var workingDirectory = $"./externals/{artifact.Id}";

--- a/Facebook.iOS/build.cake
+++ b/Facebook.iOS/build.cake
@@ -244,6 +244,7 @@ void CreateAndInstallPodfile (Artifact artifact)
 
 void BuildSdkOnPodfile (Artifact artifact)
 {
+	var baseBuildArch = Platform.iOSArmV7;
 	var platforms = new [] { baseBuildArch, Platform.iOSArm64, Platform.iOSSimulator64, Platform.iOSSimulator };
 
 	var podsProject = "./Pods/Pods.xcodeproj";


### PR DESCRIPTION
Hi,

This PR will fix the issue when application crashing after v.5.0.2 components update on non arm64 devises. And also will fix the building issue as it fix dependency resolution for generated pod files.

First issue (fixes #138)

**ARM32 Crash issue on iOS (AppStore & TestFlight only)**

The result of this is because FBCoreKit.framework and other frameworks has "Required device capabilities" property set to  "ARM64" in the info.plist.
As result of this - after AppSlacing process on AppStore / TestFlight application crashed with below stackstrace:

`
Library not loaded: @rpath/FBSDKLoginKit.framework/FBSDKLoginKit | Referenced from: /var/containers/Bundle/Application/{GUID}/{AppBundleName}.app/{AppBundleName} | Reason: image not found
`

This is because as base image for Lipo we used first built framework version (in our case ARM64) witch by default will have those  "Required device capabilities" property set to  "ARM64", just because it was build specifically for ARM64 platform.

Quick fix will be to build ARMv7 first. But by right we should probably combine ARMv7 + ARM64 together 

**This fix was verified on AppStore & TestFlight already and now it works as expected on ARM64 and ARMv7 platforms**


*Second Issue*
Dependency resolution issue. 
If you will try to run the build.sh now - you will not able to build the packages. This is because the  dependencies (like for LoginKit, MarketingKit) will be resolved by Cocapods automatically using last version. As example here the dependency resolution for LoginKit:

`
LoginKit -> 5.0.2
CoreKit -> 5.6.0
`

While we expect to get:
`
LoginKit -> 5.0.2
CoreKit -> 5.0.2
`

This PR will also fix those issue by added required dependencies to PodFile manually.

Thanks.