### PR TITLE
Software Bill of Materials (SBOM) manifest generation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,25 +47,20 @@ jobs:
             boots $(LegacyXamarinAndroidPkg)
           condition: eq(variables['System.JobName'], 'macos')
 
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))) }}:
-    - template: compliance/sbom/job.v1.yml@internal-templates
-      parameters:
-        artifactNames: ['nuget']
-        packageName: 'Xamarin Facebook Components'
-        packageFilter: '*.nupkg'
-        dependsOn: [ 'build' ]
-
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv')) }}:
     - template: compliance/sbom/job.v1.yml@internal-templates
       parameters:
-        artifactNames: ['nuget-signed']
         packageName: 'Xamarin Facebook Components'
         packageFilter: '*.nupkg'
-        dependsOn: [ 'signing' ]
-
+        $ {{ if not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
+          artifactNames: ['nuget']
+          dependsOn: [ 'build' ]
+        $ {{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
+          artifactNames: ['nuget-signed']
+          dependsOn: [ 'signing' ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,9 +58,9 @@ jobs:
       parameters:
         packageName: 'Xamarin Facebook Components'
         packageFilter: '*.nupkg'
-        $ {{ if not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
+        ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
           artifactNames: ['nuget']
           dependsOn: [ 'build' ]
-        $ {{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
+        ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
           artifactNames: ['nuget-signed']
           dependsOn: [ 'signing' ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,12 +3,21 @@ trigger:
   - refs/tags/*
 
 variables:
-  DotNetVersion: 6.0.100-rc.1.21463.6
+- group: Xamarin-Secrets
+- name: GitHub.Token
+  value: $(github--pat--vs-mobiletools-engineering-service)
+- name: DotNetVersion
+  value: 6.0.100-rc.1.21463.6
   # NOTE: there wasn't a public release of 16.11 for macOS
-  LegacyXamarinAndroidPkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
-  LegacyXamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
-  BUILD_COMMIT: $(Build.SourceVersion)
-  BUILD_NUMBER: $(Build.BuildNumber)
+- name: LegacyXamarinAndroidPkg
+  value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
+- name: LegacyXamarinAndroidVsix
+  value: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
+- name: BUILD_COMMIT
+  value: $(Build.SourceVersion)
+- name: BUILD_NUMBER
+  value: $(Build.BuildNumber)
+
 
 resources:
   repositories:
@@ -39,15 +48,34 @@ jobs:
             versionSpec: '11'
             jdkArchitectureOption: 'x64'
             jdkSourceOption: 'PreInstalled'
-  
+
       preBuildSteps:
         - pwsh: |
             dotnet tool install --global boots
             boots $(LegacyXamarinAndroidPkg)
           condition: eq(variables['System.JobName'], 'macos')
 
+  - ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
+    - template: compliance/sbom/job.v1.yml@internal-templates
+      parameters:
+        artifactNames: ['nuget']
+        packageName: 'Xamarin Facebook Components'
+        packageFilter: '*.nupkg'
+        GitHub.Token: $(GitHub.Token)
+        dependsOn: [ 'build' ]
+
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+
+    - template: compliance/sbom/job.v1.yml@internal-templates
+      parameters:
+        artifactNames: ['nuget-signed']
+        packageName: 'Xamarin Facebook Components'
+        packageFilter: '*.nupkg'
+        GitHub.Token: $(GitHub.Token)
+        dependsOn: [ 'signing' ]
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
   - refs/tags/*
 
 variables:
-  DotNetVersion: 6.0.100-rc.1.21463.6
+  DotNetVersion: 6.0.102
   # NOTE: there wasn't a public release of 16.11 for macOS
   LegacyXamarinAndroidPkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
   LegacyXamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
             boots $(LegacyXamarinAndroidPkg)
           condition: eq(variables['System.JobName'], 'macos')
 
-  - ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))) }}:
     - template: compliance/sbom/job.v1.yml@internal-templates
       parameters:
         artifactNames: ['nuget']
@@ -61,11 +61,11 @@ jobs:
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
     - template: compliance/sbom/job.v1.yml@internal-templates
       parameters:
         artifactNames: ['nuget-signed']
         packageName: 'Xamarin Facebook Components'
         packageFilter: '*.nupkg'
         dependsOn: [ 'signing' ]
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
   - ${{ if and(eq(variables['System.TeamProject'], 'devdiv')) }}:
-    - template: compliance/sbom/job.v1.yml@internal-templates
+    - template: compliance/sbom/job.v1.yml@internal-templates             # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
       parameters:
         packageName: 'Xamarin Facebook Components'
         packageFilter: '*.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,21 +3,12 @@ trigger:
   - refs/tags/*
 
 variables:
-- group: Xamarin-Secrets
-- name: GitHub.Token
-  value: $(github--pat--vs-mobiletools-engineering-service)
-- name: DotNetVersion
-  value: 6.0.100-rc.1.21463.6
+  DotNetVersion: 6.0.100-rc.1.21463.6
   # NOTE: there wasn't a public release of 16.11 for macOS
-- name: LegacyXamarinAndroidPkg
-  value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
-- name: LegacyXamarinAndroidVsix
-  value: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
-- name: BUILD_COMMIT
-  value: $(Build.SourceVersion)
-- name: BUILD_NUMBER
-  value: $(Build.BuildNumber)
-
+  LegacyXamarinAndroidPkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
+  LegacyXamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
+  BUILD_COMMIT: $(Build.SourceVersion)
+  BUILD_NUMBER: $(Build.BuildNumber)
 
 resources:
   repositories:
@@ -61,7 +52,6 @@ jobs:
         artifactNames: ['nuget']
         packageName: 'Xamarin Facebook Components'
         packageFilter: '*.nupkg'
-        GitHub.Token: $(GitHub.Token)
         dependsOn: [ 'build' ]
 
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
@@ -75,7 +65,6 @@ jobs:
         artifactNames: ['nuget-signed']
         packageName: 'Xamarin Facebook Components'
         packageFilter: '*.nupkg'
-        GitHub.Token: $(GitHub.Token)
         dependsOn: [ 'signing' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,6 @@ jobs:
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv')) }}:
     - template: compliance/sbom/job.v1.yml@internal-templates             # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
       parameters:
         packageName: 'Xamarin Facebook Components'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ jobs:
   - template: .ci/build.yml@components
     parameters:
       areaPath: 'DevDiv\VS Client - Runtime SDKs'
+      windowsImage: windows-2019
       xcode: 13.0
       initSteps:
         - task: UseDotNet@2


### PR DESCRIPTION
Per Executive Order (EO) produce a Software Bill of Materials (SBOM) capturing the produced nuget files from a dedicated job
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator

As a result of this change you will find an artifact named `sbom` attached to each build.  Within that artifact is a `manifest.json` file under a `_manifest` directory capturing all of the packages that constitute the `Software Bill of Materials` 

The `sbom` job captures the nuget package files (*.nupkg) published (uploaded) by the build