### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,168 +1,169 @@
 {
-	"Registrations": [
-		{
-			"Component": {
-				"Type": "Maven",
-				"Maven": {
-					"ArtifactId": "facebook-android-sdk",
-					"GroupId": "com.facebook.android",
-					"Version": "11.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Maven",
-				"Maven": {
-					"ArtifactId": "facebook-core",
-					"GroupId": "com.facebook.android",
-					"Version": "11.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Maven",
-				"Maven": {
-					"ArtifactId": "facebook-common",
-					"GroupId": "com.facebook.android",
-					"Version": "11.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Maven",
-				"Maven": {
-					"ArtifactId": "facebook-login",
-					"GroupId": "com.facebook.android",
-					"Version": "11.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Maven",
-				"Maven": {
-					"ArtifactId": "facebook-share",
-					"GroupId": "com.facebook.android",
-					"Version": "11.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Maven",
-				"Maven": {
-					"ArtifactId": "facebook-applinks",
-					"GroupId": "com.facebook.android",
-					"Version": "11.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Maven",
-				"Maven": {
-					"ArtifactId": "facebook-messenger",
-					"GroupId": "com.facebook.android",
-					"Version": "11.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Maven",
-				"Maven": {
-					"ArtifactId": "facebook-gamingservices",
-					"GroupId": "com.facebook.android",
-					"Version": "11.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Maven",
-				"Maven": {
-					"ArtifactId": "audience-network-sdk",
-					"GroupId": "com.facebook.android",
-					"Version": "6.6.0"
-				}
-			}
-		},
-		{
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "FBAudienceNetwork",
-                    "Version": "6.9.0",
-                    "DownloadUrl": "https://developers.facebook.com/resources/FBAudienceNetwork-6.9.0.zip"
-                }
-            }
-        },
-		{
-			"Component": {
-				"Type": "Pod",
-				"Pod": {
-					"Name": "FBSDKCoreKit",
-					"Version": "12.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Pod",
-				"Pod": {
-					"Name": "FBSDKCoreKit_Basics",
-					"Version": "12.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Pod",
-				"Pod": {
-					"Name": "FBAEMKit",
-					"Version": "12.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Pod",
-				"Pod": {
-					"Name": "FBSDKLoginKit",
-					"Version": "12.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Pod",
-				"Pod": {
-					"Name": "FBSDKShareKit",
-					"Version": "12.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Pod",
-				"Pod": {
-					"Name": "FBSDKGamingServicesKit",
-					"Version": "12.2.0"
-				}
-			}
-		},
-		{
-			"Component": {
-				"Type": "Pod",
-				"Pod": {
-					"Name": "FacebookGamingServices",
-					"Version": "12.2.0"
-				}
-			}
-		}		
-	],
-	"Version": 1
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "facebook-android-sdk",
+          "GroupId": "com.facebook.android",
+          "Version": "11.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "facebook-core",
+          "GroupId": "com.facebook.android",
+          "Version": "11.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "facebook-common",
+          "GroupId": "com.facebook.android",
+          "Version": "11.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "facebook-login",
+          "GroupId": "com.facebook.android",
+          "Version": "11.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "facebook-share",
+          "GroupId": "com.facebook.android",
+          "Version": "11.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "facebook-applinks",
+          "GroupId": "com.facebook.android",
+          "Version": "11.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "facebook-messenger",
+          "GroupId": "com.facebook.android",
+          "Version": "11.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "facebook-gamingservices",
+          "GroupId": "com.facebook.android",
+          "Version": "11.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "audience-network-sdk",
+          "GroupId": "com.facebook.android",
+          "Version": "6.6.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "FBAudienceNetwork",
+          "Version": "6.9.0",
+          "DownloadUrl": "https://developers.facebook.com/resources/FBAudienceNetwork-6.9.0.zip"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Pod",
+        "Pod": {
+          "Name": "FBSDKCoreKit",
+          "Version": "12.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Pod",
+        "Pod": {
+          "Name": "FBSDKCoreKit_Basics",
+          "Version": "12.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Pod",
+        "Pod": {
+          "Name": "FBAEMKit",
+          "Version": "12.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Pod",
+        "Pod": {
+          "Name": "FBSDKLoginKit",
+          "Version": "12.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Pod",
+        "Pod": {
+          "Name": "FBSDKShareKit",
+          "Version": "12.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Pod",
+        "Pod": {
+          "Name": "FBSDKGamingServicesKit",
+          "Version": "12.2.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Pod",
+        "Pod": {
+          "Name": "FacebookGamingServices",
+          "Version": "12.2.0"
+        }
+      }
+    }
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.