### PR TITLE
Update to Facebook SDK 11.3.0 for Android

### DIFF
--- a/Facebook.Android/build.cake
+++ b/Facebook.Android/build.cake
@@ -1,7 +1,7 @@
 #addin nuget:?package=Cake.FileHelpers&version=3.2.1
 
-var FB_VERSION = "11.2.0";
-var NUGET_VERSION = "11.2.0.1";
+var FB_VERSION = "11.3.0";
+var NUGET_VERSION = "11.3.0.0";
 
 var BUILD_COMMIT = EnvironmentVariable("BUILD_COMMIT") ?? "DEV";
 var BUILD_NUMBER = EnvironmentVariable("BUILD_NUMBER") ?? "DEBUG";


### PR DESCRIPTION
This PR updates the Facebook SDK to version 11.3.0 for Android builds. This should fix an error in the Facebook Login (https://github.com/xamarin/FacebookComponents/issues/236, https://github.com/facebook/facebook-android-sdk/issues/997) without needing any further changes.